### PR TITLE
Only run tests from the `tests/unit` directory

### DIFF
--- a/config-defaults.js
+++ b/config-defaults.js
@@ -5,8 +5,8 @@ module.exports = {
    * then loaded into karma.
    */
   files: [
-    'tests/**/*.spec.js',
-    'tests/**/*.spec.ts',
+    'tests/unit/**/*.spec.js',
+    'tests/unit/**/*.spec.ts',
   ],
 
   /**


### PR DESCRIPTION
Currently, `vue-cli-plugin-unit-karma` is running all tests in the `tests` directory.  This is a problem, because it's also attempting to run my [vue-cli-plugin-e2e-cypress](https://www.npmjs.com/package/@vue/cli-plugin-e2e-cypress#configuration) tests in the `tests/e2e` directory.

According to the docs, it should only be running `tests/unit`.
https://github.com/davidwallacejackson/vue-cli-plugin-unit-karma#usage

This PR changes it to only run tests in the `tests/unit` directory