### PR TITLE
Only remove target from webpack config

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,11 +15,11 @@ module.exports = (api, projectOptions) => {
       }
     },
     (args, rawArgv) => {
-      let webpackConfigForTests = api.resolveChainableWebpackConfig()
-        .target()
-          .clear()
+      api.chainWebpack((chain) => {
+        chain.delete('target');
+      });
 
-      webpackConfigForTests = webpackConfigForTests.toConfig()
+      webpackConfigForTests = api.resolveWebpackConfig();
 
       // workaround for: https://github.com/webpack-contrib/karma-webpack/pull/325
       // TODO: remove this when the above PR is merged


### PR DESCRIPTION
This plugin was not respecting the proper webpack config generated by vue cli. The intention was to remove the `target` property, but it removed more than just that.

This probably fixes #9 